### PR TITLE
JSON 'Database'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20240303</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
             <artifactId>commons-io</artifactId>
             <version>2.16.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 

--- a/src/main/java/com/comicbookreader/Main.java
+++ b/src/main/java/com/comicbookreader/Main.java
@@ -19,6 +19,9 @@ public class Main {
             importedComicPath.mkdir();
         }
 
+        File appDataJson = new File("appdata/data.json");
+        File userDataJson = new File("userdata/data.json");
+
         // Initialiseert leeg Mainmenu -- Zorgt dat de app uberhaupt openblijft.
         ArrayList<Comicbook> comicbooks = new ArrayList<>();
         new Mainmenu(comicbooks);

--- a/src/main/java/com/comicbookreader/Main.java
+++ b/src/main/java/com/comicbookreader/Main.java
@@ -8,60 +8,43 @@ import java.util.List;
 
 public class Main {
     public static void main(String[] args) throws IOException {
+        // Setup the application directories
+        setupDataDirectories();
 
-        Path directory = Paths.get("imported_comics");
+        // Perform directory scan or load comics from JSON
+        Path comicDirectory = Paths.get("imported_comics");
+        List<String> comicPaths = DirectoryScanner.getComicFilePaths(comicDirectory, "cbr", "cbz", "nhlcomic");
 
-        // paths to data folders
+        // Load comics from paths and initialize the Mainmenu
+        ComicBookLoader.loadComics(comicPaths);
+        ArrayList<Comicbook> comicList = ComicBookLoader.getComicList();
+        new Mainmenu(comicList);
+
+        // Cleanup unzipped .cbr comic books on shutdown
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                new CBRParser().cleanup();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }));
+    }
+
+    private static void setupDataDirectories() throws IOException {
         Path appDataDirectory = Paths.get("appdata");
         Path userDataDirectory = Paths.get("userdata");
 
-        List<String> comicPath = DirectoryScanner.getComicFilePaths(directory, ".cbz", ".cbr", ".nhlcomic");
-      
-        File importedComicPath = new File("imported_comics");
+        Files.createDirectories(appDataDirectory);
+        Files.createDirectories(userDataDirectory);
 
-        if (!importedComicPath.exists()) {
-            importedComicPath.mkdir();
-        }
-
-        // Maakt data files aan en initialiseert een lege 'array'
         File appDataJson = new File("appdata/data.json");
         File userDataJson = new File("userdata/data.json");
-        if (!Files.exists(appDataDirectory)) {
-            Files.createDirectory(appDataDirectory);
-            if (!appDataJson.exists()) {
-                appDataJson.createNewFile();
-                BufferedWriter writer = new BufferedWriter(new FileWriter(appDataJson));
-                writer.write("[]");
-                writer.close();
-            }
 
+        if (!appDataJson.exists()) {
+            Files.writeString(appDataJson.toPath(), "[]"); // Initialize as empty array
         }
-        if (!Files.exists(userDataDirectory)) {
-            Files.createDirectory(userDataDirectory);
-            if (!userDataJson.exists()) {
-                userDataJson.createNewFile();
-                BufferedWriter writer = new BufferedWriter(new FileWriter(userDataJson));
-                writer.write("[]");
-                writer.close();
-            }
+        if (!userDataJson.exists()) {
+            Files.writeString(userDataJson.toPath(), "{}"); // Initialize with empty JSON object
         }
-
-        // Initialiseert leeg Mainmenu -- Zorgt dat de app uberhaupt openblijft.
-        ArrayList<Comicbook> comicbooks = new ArrayList<>();
-        new Mainmenu(comicbooks);
-
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                CBRParser cbrParser = new CBRParser();
-                try {
-                    cbrParser.cleanup();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
-
-
     }
 }

--- a/src/main/java/com/comicbookreader/Main.java
+++ b/src/main/java/com/comicbookreader/Main.java
@@ -11,6 +11,10 @@ public class Main {
 
         Path directory = Paths.get("imported_comics");
 
+        // paths to data folders
+        Path appDataDirectory = Paths.get("appdata");
+        Path userDataDirectory = Paths.get("userdata");
+
         List<String> comicPath = DirectoryScanner.getComicFilePaths(directory, ".cbz", ".cbr", ".nhlcomic");
       
         File importedComicPath = new File("imported_comics");
@@ -19,8 +23,28 @@ public class Main {
             importedComicPath.mkdir();
         }
 
+        // Maakt data files aan en initialiseert een lege 'array'
         File appDataJson = new File("appdata/data.json");
         File userDataJson = new File("userdata/data.json");
+        if (!Files.exists(appDataDirectory)) {
+            Files.createDirectory(appDataDirectory);
+            if (!appDataJson.exists()) {
+                appDataJson.createNewFile();
+                BufferedWriter writer = new BufferedWriter(new FileWriter(appDataJson));
+                writer.write("[]");
+                writer.close();
+            }
+
+        }
+        if (!Files.exists(userDataDirectory)) {
+            Files.createDirectory(userDataDirectory);
+            if (!userDataJson.exists()) {
+                userDataJson.createNewFile();
+                BufferedWriter writer = new BufferedWriter(new FileWriter(userDataJson));
+                writer.write("[]");
+                writer.close();
+            }
+        }
 
         // Initialiseert leeg Mainmenu -- Zorgt dat de app uberhaupt openblijft.
         ArrayList<Comicbook> comicbooks = new ArrayList<>();

--- a/src/main/java/com/comicbookreader/comicbook/Author.java
+++ b/src/main/java/com/comicbookreader/comicbook/Author.java
@@ -6,4 +6,30 @@ import java.util.List;
 public class Author {
     public String name;
     public List<Comicbook> comicbookList;
+
+    public Author(String name, List<Comicbook> comicbookList) {
+        this.name = name;
+        this.comicbookList = comicbookList;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Comicbook> getComicbookList() {
+        return comicbookList;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setComicbookList(List<Comicbook> comicbookList) {
+        this.comicbookList = comicbookList;
+    }
+
+    public void deleteAuthor() {
+        name = null;
+        comicbookList.remove(this);
+    }
 }

--- a/src/main/java/com/comicbookreader/comicbook/CBRParser.java
+++ b/src/main/java/com/comicbookreader/comicbook/CBRParser.java
@@ -8,10 +8,7 @@ import org.apache.commons.io.FileUtils;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.ArrayList;
 
 public class CBRParser implements FileParser {
@@ -43,7 +40,7 @@ public class CBRParser implements FileParser {
                         rar.extractFile(fileHeader, fos);
                         try {
                             BufferedImage image = ImageIO.read(extractedFile);
-                            pages.add(new Page(pagenumber++, extractedFile.getAbsolutePath(), image));
+                            pages.add(new Page(pagenumber++, extractedFile.toString(), image));
                         } catch (IOException e) {
                             System.err.println("Error reading image " + extractedFile.getAbsolutePath());
                         }

--- a/src/main/java/com/comicbookreader/comicbook/ComicBookLoader.java
+++ b/src/main/java/com/comicbookreader/comicbook/ComicBookLoader.java
@@ -1,45 +1,37 @@
 package com.comicbookreader.comicbook;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 public class ComicBookLoader {
     private static ArrayList<Comicbook> comicList = new ArrayList<>();
 
-    public static void startDirectoryScan(Path directory, String... extensions) {
-        List<String> comicFiles = DirectoryScanner.getComicFilePaths(directory, extensions);
-        System.out.println(comicFiles); // prints imported comics to console
-        for (String comicFile : comicFiles) {
-            routeToParser(comicFile);
+    public static void loadComics(List<String> comicPaths) {
+        for (String comicPath : comicPaths) {
+            routeToParser(comicPath);
         }
     }
 
     private static void routeToParser(String filePath) {
         try {
             ArrayList<Page> pages;
-            CBZParser cbzParser = new CBZParser();
-            CBRParser cbrParser = new CBRParser();
-
             if (filePath.endsWith(".cbr")) {
-                pages = cbrParser.extractPages(filePath);
-            } else if (filePath.endsWith(".cbz")) {
-                pages = cbzParser.extractPages(filePath);
-            } else if (filePath.endsWith(".nhlcomic")){
-                pages = cbzParser.extractPages(filePath);
-            } else{
+                pages = new CBRParser().extractPages(filePath);
+            } else if (filePath.endsWith(".cbz") || filePath.endsWith(".nhlcomic")) {
+                pages = new CBZParser().extractPages(filePath);
+            } else {
                 System.out.println("Unsupported file type: " + filePath);
                 return;
             }
-
             Comicbook comicbook = Comicbook.fromFilePath(filePath, pages);
             comicList.add(comicbook);
         } catch (IOException e) {
-            e.printStackTrace();
+            System.err.println("Error loading comic: " + e.getMessage());
         }
     }
+
     public static ArrayList<Comicbook> getComicList() {
-        return comicList; // Return the list of loaded comics
+        return comicList;
     }
 }

--- a/src/main/java/com/comicbookreader/comicbook/ComicBookLoader.java
+++ b/src/main/java/com/comicbookreader/comicbook/ComicBookLoader.java
@@ -24,7 +24,7 @@ public class ComicBookLoader {
                 System.out.println("Unsupported file type: " + filePath);
                 return;
             }
-            Comicbook comicbook = Comicbook.fromFilePath(filePath, pages);
+            Comicbook comicbook = Comicbook.fromFilePath(filePath, pages, filePath);
             comicList.add(comicbook);
         } catch (IOException e) {
             System.err.println("Error loading comic: " + e.getMessage());

--- a/src/main/java/com/comicbookreader/comicbook/Comicbook.java
+++ b/src/main/java/com/comicbookreader/comicbook/Comicbook.java
@@ -39,6 +39,12 @@ public class Comicbook {
         this.pages = new ArrayList<>();
     }
 
+    public ArrayList<Page> invertPages() {
+        Collections.reverse(pages);
+        return pages;
+    }
+
+    // getters & setters
     public String getName() {
         return name;
     }
@@ -47,9 +53,47 @@ public class Comicbook {
         return pages;
     }
 
-    public ArrayList<Page> invertPages() {
-            Collections.reverse(pages);
-        return pages;
+    public int getProgression() {
+        return progression;
     }
+
+    public boolean getIsRead(){
+        return read;
+    }
+
+    public boolean getIsFavourite(){
+        return favourite;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setName(String name){
+        this.name = name;
+    }
+
+    public void setProgression(Page page ,int progression){
+        int currentpage = page.getCurrentPageNumber();
+
+        if(currentpage < pages.size()){
+            this.progression = progression;
+            return;
+        }
+        setIsRead(true);
+    }
+
+    public void setIsRead(boolean read) {
+        this.read = read;
+    }
+
+    public void setFavourite(boolean favourite) {
+        this.favourite = favourite;
+    }
+
+    public void setPath(String path){
+        this.path = path;
+    }
+
 }
 

--- a/src/main/java/com/comicbookreader/comicbook/Comicbook.java
+++ b/src/main/java/com/comicbookreader/comicbook/Comicbook.java
@@ -88,10 +88,11 @@ public class Comicbook {
     public boolean getIsRead(){
         return read;
     }
-    public static Comicbook fromFilePath(String filePath, List<Page> pages) {
+
+    public static Comicbook fromFilePath(String filePath, List<Page> pages, String path) {
         String name = filePath.substring(filePath.lastIndexOf("/") + 1, filePath.lastIndexOf("."));
         System.out.println(name);
-        return new Comicbook(name, pages);
+        return new Comicbook(name, pages, path);
     }
 
     public boolean getIsFavourite(){

--- a/src/main/java/com/comicbookreader/comicbook/Comicbook.java
+++ b/src/main/java/com/comicbookreader/comicbook/Comicbook.java
@@ -1,15 +1,20 @@
 package com.comicbookreader.comicbook;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Comicbook {
     public String name;
     public ArrayList<Author> authorList;
     public ArrayList<Page> pages;
+    @JsonIgnore
     public BufferedImage coverImage;
     public boolean read;
     public int progression;

--- a/src/main/java/com/comicbookreader/comicbook/Comicbook.java
+++ b/src/main/java/com/comicbookreader/comicbook/Comicbook.java
@@ -3,10 +3,8 @@ package com.comicbookreader.comicbook;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -43,14 +41,35 @@ public class Comicbook {
         this.pages = new ArrayList<>(pages);
     }
 
+    public Comicbook(String name, List<Page>pages, String path) {
+        this.name = name;
+        this.pages = new ArrayList<>(pages);
+        this.path = path;
+    }
+
+    public Comicbook() {
+    }
 
     public Comicbook(List<Page> pages) {
         this.pages = new ArrayList<>(pages);
     }
 
+
     public ArrayList<Page> invertPages() {
         Collections.reverse(pages);
         return pages;
+    }
+
+    public void loadPages() {
+        if (pages.isEmpty()) {
+            try {
+                this.pages = name.endsWith(".cbr")
+                        ? new CBRParser().extractPages(this.path)
+                        : new CBZParser().extractPages(this.path);
+            } catch (IOException e) {
+                System.err.println("Error reloading pages: " + e.getMessage());
+            }
+        }
     }
 
     // getters & setters
@@ -85,6 +104,10 @@ public class Comicbook {
 
     public void setName(String name){
         this.name = name;
+    }
+
+    public void setPages(ArrayList<Page> pages) {
+        this.pages = pages;
     }
 
     public void setProgression(Page page ,int progression){

--- a/src/main/java/com/comicbookreader/comicbook/DirectoryScanner.java
+++ b/src/main/java/com/comicbookreader/comicbook/DirectoryScanner.java
@@ -1,5 +1,10 @@
 package com.comicbookreader.comicbook;
 
+import com.comicbookreader.user.Userdata;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.ArrayList;
@@ -8,31 +13,66 @@ import java.util.stream.Stream;
 
 public class DirectoryScanner {
 
-    public static List<String> getComicFilePaths(Path directory, String... extensions) {
-        CBZParser cbzParser = new CBZParser();
-        CBRParser cbrParser = new CBRParser();
+    public static List<String> getComicFilePaths(Path directory, String... extensions) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        String userDataPath = "userdata/data.json";
+        File userDataFile = new File(userDataPath);
+        String appDataPath = "appdata/data.json";
+        File appDataFile = new File(appDataPath);
+
+        // Load userdata to check initial scan status
+        Userdata userdata = mapper.readValue(userDataFile, Userdata.class);
+
         List<String> comicFiles = new ArrayList<>();
-
-        try (Stream<Path> paths = Files.walk(directory, 1)) {  // Use walk with depth 1 to avoid subdirectories
-            paths
-                    .filter(Files::isRegularFile)  // Only include regular files, ignore directories
-                    .filter(path -> {
-                        // Check if file has one of the desired extensions
-                        String fileName = path.getFileName().toString().toLowerCase();
-                        for (String extension : extensions) {
-                            if (fileName.endsWith(extension)) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    })
-                    .map(Path::toString)  // Convert to String representation
-                    .forEach(comicFiles::add);
-
-        } catch (IOException e) {
-            e.printStackTrace();
+        if (appDataFile.exists() && userdata.getHadInitialScan()) {
+            // Step 2: Load from appdata/data.json
+            List<Comicbook> comicList = mapper.readValue(appDataFile, new TypeReference<>() {});
+            for (Comicbook comic : comicList) {
+                comicFiles.add(comic.getPath()); // Use paths stored in JSON
+            }
+        } else {
+            // Step 1: Perform directory scan, set hadInitialScan to true
+            comicFiles = performInitialDirectoryScan(directory, extensions, appDataFile, userdata, userDataFile);
         }
 
         return comicFiles;
     }
+
+    private static List<String> performInitialDirectoryScan(Path directory, String[] extensions,
+                                                            File appDataFile, Userdata userdata,
+                                                            File userDataFile) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        List<String> comicFiles = new ArrayList<>();
+        List<Comicbook> comicList = new ArrayList<>();
+
+        try (Stream<Path> paths = Files.walk(directory, 1)) {
+            paths.filter(Files::isRegularFile).forEach(path -> {
+                String fileName = path.getFileName().toString();
+                for (String extension : extensions) {
+                    if (fileName.endsWith(extension)) {
+                        ArrayList<Page> pages;
+                        try {
+                            pages = fileName.endsWith(".cbr")
+                                    ? new CBRParser().extractPages(path.toString())
+                                    : new CBZParser().extractPages(path.toString());
+                        } catch (IOException e) {
+                            System.err.println("Error extracting pages: " + e.getMessage());
+                            continue;
+                        }
+                        Comicbook comicbook = new Comicbook(fileName, pages, path.toString());
+                        comicList.add(comicbook);
+                        comicFiles.add(path.toString());
+                    }
+                }
+            });
+        }
+
+        // Save to appDataFile and update userdata
+        mapper.writeValue(appDataFile, comicList);
+        userdata.setHadInitialScan(true);
+        mapper.writeValue(userDataFile, userdata);
+
+        return comicFiles;
+    }
+
 }

--- a/src/main/java/com/comicbookreader/comicbook/Mainmenu.java
+++ b/src/main/java/com/comicbookreader/comicbook/Mainmenu.java
@@ -1,6 +1,5 @@
 package com.comicbookreader.comicbook;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.swing.*;
@@ -17,10 +16,6 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-
 public class Mainmenu implements ActionListener {
 
     private JFrame frame;
@@ -34,25 +29,27 @@ public class Mainmenu implements ActionListener {
     private String appDataPath = "appdata/data.json";
     private File appDataFile = new File(appDataPath);
 
-
     public Mainmenu(ArrayList<Comicbook> comicList) {
-        this.comicList = comicList;
-    public Mainmenu() {
-        Path comicDirectory = Path.of("imported_comics");
-        ComicBookLoader.startDirectoryScan(comicDirectory, "cbr", "cbz", "nhlcomic");
-
-        this.comicList = ComicBookLoader.getComicList(); // Retrieve the loaded comics
+        this.comicList = comicList; // Use the loaded comics directly
         initUI();
     }
 
     public void addComic(Comicbook comicbook) {
         comicList.add(comicbook);
-        listModel.addElement(comicbook.getName());
+        listModel.addElement(comicbook.getName()); // Update display list
+
+        // Save new comic to JSON file
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            List<Comicbook> tempComicList = new ArrayList<>(comicList);
+            mapper.writeValue(appDataFile, tempComicList);
+            System.out.println("Comic added to JSON: " + comicbook.getName());
+        } catch (IOException e) {
+            System.err.println("Error saving to JSON: " + e.getMessage());
+        }
     }
 
     public void initUI() {
-        ObjectMapper mapper = new ObjectMapper();
-
         frame = new JFrame("Comic Book Reader - Main Menu");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
@@ -60,89 +57,71 @@ public class Mainmenu implements ActionListener {
         frame.setSize(dim.width, dim.height);
 
         scrollPaneWidth = frame.getSize().width / 8;
-
         frame.setLayout(new BorderLayout());
 
-        //Gets the list of comics
-        getComicList(comicList);
+        // Display comics in list
+        getComicList();
         JScrollPane scrollPane = new JScrollPane(displayList);
         scrollPane.setPreferredSize(new Dimension(scrollPaneWidth, frame.getHeight()));
         frame.add(scrollPane, BorderLayout.WEST);
 
-        //shows the first page when clicked on a comic
         imageLabel = new JLabel();
         frame.add(imageLabel, BorderLayout.CENTER);
 
         JButton selectButton = new JButton("Select Comic");
         selectButton.addActionListener(this);
 
-        JButton InvertButton = new JButton("Invert Comic");
-        InvertButton.addActionListener(this);
+        JButton invertButton = new JButton("Invert Comic");
+        invertButton.addActionListener(this);
 
         JButton addButton = new JButton("Import Comic");
         addButton.setPreferredSize(new Dimension(scrollPaneWidth, addButton.getPreferredSize().height));
 
-        addButton.addActionListener(e -> {
-            JFileChooser fileChooser = new JFileChooser();
-            fileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-            fileChooser.setFileFilter(new javax.swing.filechooser.FileNameExtensionFilter("Comic Book Files", "cbr", "cbz", "nhlcomic"));
+        addButton.addActionListener(e -> importComic());
 
-            int result = fileChooser.showOpenDialog(frame);
-            if (result == JFileChooser.APPROVE_OPTION) {
-                File selectedFile = fileChooser.getSelectedFile();
-                Path targetDirectory = Path.of("imported_comics");
-
-                try {
-                    Path targetPath = targetDirectory.resolve(selectedFile.getName());
-                    Files.move(selectedFile.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING);
-                    System.out.println("Bestand verplaatst naar: " + targetPath);
-
-                    ArrayList<Page> pages;
-                    if (selectedFile.toString().endsWith(".cbr")) {
-                        pages = new CBRParser().extractPages(targetPath.toString());
-                    } else {
-                        pages = new CBZParser().extractPages(targetPath.toString());
-                    }
-
-                    Comicbook comicbook = Comicbook.fromFilePath(selectedFile.toString(), pages);
-                    addComic(comicbook);  // Voeg de nieuwe comic toe aan de bestaande lijst
-
-                    List<Comicbook> tempComicList = new ArrayList<>();
-                    if (appDataFile.exists() && appDataFile.length() > 2) {
-                        tempComicList = mapper.readValue(appDataFile, new TypeReference<>() {});
-                    }
-                    try {
-                        tempComicList.add(comicbook);
-                        mapper.writeValue(appDataFile, tempComicList);
-                        System.out.println("Data succesvol geschreven naar JSON.");
-                        System.out.println("Comic toegevoegd aan JSON: " + comicbook.getName());
-                    } catch (IOException ex) {
-                        System.err.println("Fout bij schrijven naar JSON-bestand: " + ex.getMessage());
-                    }
-
-                } catch (IOException ex) {
-                    System.err.println("Fout bij het verplaatsen van bestand: " + ex.getMessage());
-                }
-            }
-        });
-
-
-        // Paneel met knoppen onder in het scherm -- Voor Import, Select & Invert
         JPanel bottomPanel = new JPanel(new BorderLayout());
         bottomPanel.add(selectButton, BorderLayout.CENTER);
-        bottomPanel.add(InvertButton, BorderLayout.EAST);
+        bottomPanel.add(invertButton, BorderLayout.EAST);
         bottomPanel.add(addButton, BorderLayout.WEST);
 
         frame.add(bottomPanel, BorderLayout.SOUTH);
-
         frame.setVisible(true);
     }
 
-    public void getComicList(ArrayList<Comicbook> comicList) {
-        //get the list of comics
+    private void importComic() {
+        JFileChooser fileChooser = new JFileChooser();
+        fileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+        fileChooser.setFileFilter(new javax.swing.filechooser.FileNameExtensionFilter("Comic Book Files", "cbr", "cbz", "nhlcomic"));
+
+        int result = fileChooser.showOpenDialog(frame);
+        if (result == JFileChooser.APPROVE_OPTION) {
+            File selectedFile = fileChooser.getSelectedFile();
+            Path targetDirectory = Path.of("imported_comics");
+
+            try {
+                Path targetPath = targetDirectory.resolve(selectedFile.getName());
+                Files.move(selectedFile.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+                System.out.println("File moved to: " + targetPath);
+
+                ArrayList<Page> pages;
+                if (selectedFile.toString().endsWith(".cbr")) {
+                    pages = new CBRParser().extractPages(targetPath.toString());
+                } else {
+                    pages = new CBZParser().extractPages(targetPath.toString());
+                }
+
+                Comicbook comicbook = Comicbook.fromFilePath(targetPath.toString(), pages);
+                addComic(comicbook);
+
+            } catch (IOException e) {
+                System.err.println("Error moving file: " + e.getMessage());
+            }
+        }
+    }
+
+    public void getComicList() {
         listModel = new DefaultListModel<>();
         for (Comicbook comic : comicList) {
-            System.out.println(comic);
             listModel.addElement(comic.getName());
         }
         displayList = new JList<>(listModel);
@@ -155,9 +134,8 @@ public class Mainmenu implements ActionListener {
                     int selectedIndex = displayList.getSelectedIndex();
                     if (selectedIndex != -1) {
                         currentComic = comicList.get(selectedIndex);
-                        System.out.println("Comic selected: " + currentComic.getName());
                         Page firstPage = currentComic.getPages().getFirst();
-                        displayPage(currentComic.getPages().get(0));
+                        displayPage(firstPage);
                     }
                 }
             }
@@ -166,30 +144,28 @@ public class Mainmenu implements ActionListener {
 
     private void displayPage(Page page) {
         if (page.image != null) {
-            Image scaledImage = page.image.getScaledInstance(500, 700, Image.SCALE_SMOOTH);  // Adjust dimensions as needed
+            Image scaledImage = page.image.getScaledInstance(500, 700, Image.SCALE_SMOOTH);
             imageLabel.setIcon(new ImageIcon(scaledImage));
         } else {
             imageLabel.setText("No image available for this page.");
         }
     }
 
-
     @Override
     public void actionPerformed(ActionEvent e) {
         String command = e.getActionCommand();
 
-
         if (command.equals("Invert Comic") && currentComic != null) {
             currentComic.invertPages();
-            displayPage(currentComic.getPages().get(0));
+            displayPage(currentComic.getPages().getFirst());
+        } else if (command.equals("Select Comic")) {
+            int selectedIndex = displayList.getSelectedIndex();
+            if (selectedIndex != -1) {
+                currentComic = comicList.get(selectedIndex);
+                new ComicbookreaderUI(currentComic.getPages());
+            } else {
+                System.out.println("No comic selected.");
+            }
         }
-        int selectedIndex = displayList.getSelectedIndex();
-        if (selectedIndex != -1 && command.equals("Select Comic")){
-            currentComic = comicList.get(selectedIndex);
-            new ComicbookreaderUI(currentComic.getPages());
-
-        } else System.out.println("No comic selected.");
-
-
     }
 }

--- a/src/main/java/com/comicbookreader/comicbook/Mainmenu.java
+++ b/src/main/java/com/comicbookreader/comicbook/Mainmenu.java
@@ -110,7 +110,9 @@ public class Mainmenu implements ActionListener {
                     pages = new CBZParser().extractPages(targetPath.toString());
                 }
 
-                Comicbook comicbook = Comicbook.fromFilePath(targetPath.toString(), pages);
+                Comicbook comicbook = Comicbook.fromFilePath(targetPath.toString(), pages, targetPath.toString());
+
+                comicbook.setPath(targetPath.toString());
                 addComic(comicbook);
 
             } catch (IOException e) {

--- a/src/main/java/com/comicbookreader/comicbook/Mainmenu.java
+++ b/src/main/java/com/comicbookreader/comicbook/Mainmenu.java
@@ -12,6 +12,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 public class Mainmenu implements ActionListener {
@@ -22,6 +26,10 @@ public class Mainmenu implements ActionListener {
     private DefaultListModel<String> listModel;
     private ArrayList<Comicbook> comicList;
     private int scrollPaneWidth;
+
+    private String appDataPath = "appdata/data.json";
+    private File appDataFile = new File(appDataPath);
+
 
     public Mainmenu(ArrayList<Comicbook> comicList) {
         this.comicList = comicList;
@@ -34,6 +42,8 @@ public class Mainmenu implements ActionListener {
     }
 
     public void initUI() {
+        ObjectMapper mapper = new ObjectMapper();
+
         frame = new JFrame("Comic Book Reader - Main Menu");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
@@ -84,6 +94,20 @@ public class Mainmenu implements ActionListener {
 
                     Comicbook comicbook = new Comicbook(selectedFile.getName(), pages, false);
                     addComic(comicbook);  // Voeg de nieuwe comic toe aan de bestaande lijst
+
+                    List<Comicbook> tempComicList = new ArrayList<>();
+                    if (appDataFile.exists() && appDataFile.length() > 2) {
+                        tempComicList = mapper.readValue(appDataFile, new TypeReference<>() {});
+                    }
+                    try {
+                        tempComicList.add(comicbook);
+                        mapper.writeValue(appDataFile, tempComicList);
+                        System.out.println("Data succesvol geschreven naar JSON.");
+                        System.out.println("Comic toegevoegd aan JSON: " + comicbook.getName());
+                    } catch (IOException ex) {
+                        System.err.println("Fout bij schrijven naar JSON-bestand: " + ex.getMessage());
+                    }
+
                 } catch (IOException ex) {
                     System.err.println("Fout bij het verplaatsen van bestand: " + ex.getMessage());
                 }

--- a/src/main/java/com/comicbookreader/comicbook/Page.java
+++ b/src/main/java/com/comicbookreader/comicbook/Page.java
@@ -17,5 +17,9 @@ public class Page {
     }
     public Page() {}
 
+    public int getCurrentPageNumber() {
+        return number;
+    }
+
 }
 

--- a/src/main/java/com/comicbookreader/comicbook/Page.java
+++ b/src/main/java/com/comicbookreader/comicbook/Page.java
@@ -20,6 +20,8 @@ public class Page {
         this.image = image;
     }
 
+    public Page(){}
+
     public int getCurrentPageNumber() {
         return number;
     }

--- a/src/main/java/com/comicbookreader/comicbook/Page.java
+++ b/src/main/java/com/comicbookreader/comicbook/Page.java
@@ -1,12 +1,16 @@
 package com.comicbookreader.comicbook;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.awt.image.BufferedImage;
-import java.util.Collections;
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Page {
     public int number;
     public String path;
+    @JsonIgnore
     public BufferedImage image;
     public List<Annotation> annotationsList;
 

--- a/src/main/java/com/comicbookreader/user/Userdata.java
+++ b/src/main/java/com/comicbookreader/user/Userdata.java
@@ -1,0 +1,17 @@
+package com.comicbookreader.user;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Userdata {
+    public boolean hadInitialScan;
+
+    public boolean getHadInitialScan(){
+        return hadInitialScan;
+    }
+
+    public void setHadInitialScan(boolean hadInitialScan) {
+        this.hadInitialScan = hadInitialScan;
+    }
+
+}


### PR DESCRIPTION
This pull request includes several changes to enhance the comic book reader application by switching JSON libraries, improving the comic book loading process, and adding new functionalities to the `Author` and `Comicbook` classes.

### Dependency Updates:
* Replaced `org.json` with `jackson-databind` for JSON processing in `pom.xml`.
* Added `org.jetbrains.annotations` dependency to `pom.xml`.

### Main Application Enhancements:
* Refactored `Main.java` to include setup for application directories and improved the shutdown hook for cleanup.
* Enhanced `ComicBookLoader` to load comics from paths and handle different file types more efficiently.
* Updated `Mainmenu` to directly use the loaded comics and save new comics to JSON. [[1]](diffhunk://#diff-c8cf4f1bc1069dc0b75942dced99af422a7885f33be6a488e1b74deeac9d910dL27-R49) [[2]](diffhunk://#diff-c8cf4f1bc1069dc0b75942dced99af422a7885f33be6a488e1b74deeac9d910dL48-R91) [[3]](diffhunk://#diff-c8cf4f1bc1069dc0b75942dced99af422a7885f33be6a488e1b74deeac9d910dL83-R104)

### Class Additions and Modifications:
* Added constructor, getters, setters, and delete method to `Author` class.
* Introduced new methods in `Comicbook` class for loading pages, inverting pages, and managing comic properties. [[1]](diffhunk://#diff-50a05c1b24cd0ce43d730b4f34080c10b7ec4fdfd87eb07fdca7cbd6df04d96bR3-R18) [[2]](diffhunk://#diff-50a05c1b24cd0ce43d730b4f34080c10b7ec4fdfd87eb07fdca7cbd6df04d96bR44-R75) [[3]](diffhunk://#diff-50a05c1b24cd0ce43d730b4f34080c10b7ec4fdfd87eb07fdca7cbd6df04d96bL51-R135)

### File Parsing and Directory Scanning:
* Simplified `CBRParser` by consolidating import statements and minor refactoring. [[1]](diffhunk://#diff-f4709559db8a5ff8f2c95d06fbd7dfe14a95ba7a4fc0b8ea25f562f8c6a19b2dL11-R11) [[2]](diffhunk://#diff-f4709559db8a5ff8f2c95d06fbd7dfe14a95ba7a4fc0b8ea25f562f8c6a19b2dL46-R43)
* Improved `DirectoryScanner` to handle initial directory scans and load paths from JSON. [[1]](diffhunk://#diff-d1ca54b37dc1bcada6614ac69a142ffcc73d7824998632e4313f54704a208d48R3-R7) [[2]](diffhunk://#diff-d1ca54b37dc1bcada6614ac69a142ffcc73d7824998632e4313f54704a208d48L11-R77)