### PR TITLE
Settings Menu

### DIFF
--- a/src/main/java/com/comicbookreader/Main.java
+++ b/src/main/java/com/comicbookreader/Main.java
@@ -1,6 +1,7 @@
 package com.comicbookreader;
 import com.comicbookreader.comicbook.*;
 
+import javax.swing.*;
 import java.io.*;
 import java.nio.file.*;
 import java.util.ArrayList;
@@ -8,6 +9,8 @@ import java.util.List;
 
 public class Main {
     public static void main(String[] args) throws IOException {
+        System.setProperty("apple.laf.useScreenMenuBar", "true");
+
         // Setup the application directories
         setupDataDirectories();
 
@@ -19,6 +22,9 @@ public class Main {
         ComicBookLoader.loadComics(comicPaths);
         ArrayList<Comicbook> comicList = ComicBookLoader.getComicList();
         new Mainmenu(comicList);
+
+        // Start native Swing GUI
+        SwingUtilities.invokeLater(SettingsMenu::new);
 
         // Cleanup unzipped .cbr comic books on shutdown
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/src/main/java/com/comicbookreader/cleanupcrew/AppDataCleanup.java
+++ b/src/main/java/com/comicbookreader/cleanupcrew/AppDataCleanup.java
@@ -1,0 +1,35 @@
+package com.comicbookreader.cleanupcrew;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+
+import com.comicbookreader.comicbook.CBRParser;
+
+import javax.swing.*;
+
+public class AppDataCleanup {
+    private String appDataPath = "appdata";
+
+    public AppDataCleanup() throws IOException {
+        CBRParser cbrParser = new CBRParser();
+        cbrParser.cleanup();
+
+        FileUtils.deleteDirectory(new File(appDataPath));
+
+        int result = JOptionPane.showConfirmDialog(
+                null,
+                "Cleanup complete, please restart to continue",
+                "Cleanup Complete",
+                JOptionPane.DEFAULT_OPTION
+        );
+
+        new UserDataCleanup();
+        if (result == JOptionPane.OK_OPTION) {
+            System.exit(0);
+        }
+        else {
+            System.exit(-1);
+        }
+    }
+}

--- a/src/main/java/com/comicbookreader/cleanupcrew/UserDataCleanup.java
+++ b/src/main/java/com/comicbookreader/cleanupcrew/UserDataCleanup.java
@@ -1,0 +1,34 @@
+package com.comicbookreader.cleanupcrew;
+
+import com.comicbookreader.comicbook.CBRParser;
+import org.apache.commons.io.FileUtils;
+
+import javax.swing.*;
+import java.io.File;
+import java.io.IOException;
+
+public class UserDataCleanup {
+    private String userDataPath = "userdata";
+
+    public UserDataCleanup() throws IOException {
+        CBRParser cbrParser = new CBRParser();
+        cbrParser.cleanup();
+
+        FileUtils.deleteDirectory(new File(userDataPath));
+
+        int result = JOptionPane.showConfirmDialog(
+                null,
+                "Cleanup complete, please restart to continue",
+                "Cleanup Complete",
+                JOptionPane.DEFAULT_OPTION
+        );
+
+        if (result == JOptionPane.OK_OPTION) {
+            System.exit(0);
+        }
+        else {
+            System.exit(-1);
+        }
+    }
+
+}

--- a/src/main/java/com/comicbookreader/comicbook/Mainmenu.java
+++ b/src/main/java/com/comicbookreader/comicbook/Mainmenu.java
@@ -102,6 +102,9 @@ public class Mainmenu implements ActionListener {
         mainPanel.add(eastPanel, BorderLayout.EAST); // East side for InvertButton
         mainPanel.add(centerPanel, BorderLayout.CENTER); // Center for image and number
 
+        SettingsMenu settingsMenu = new SettingsMenu();
+        frame.setJMenuBar(settingsMenu.getMenuBar());
+
         frame.add(mainPanel);
         frame.setVisible(true);
     }

--- a/src/main/java/com/comicbookreader/comicbook/SettingsMenu.java
+++ b/src/main/java/com/comicbookreader/comicbook/SettingsMenu.java
@@ -1,0 +1,76 @@
+package com.comicbookreader.comicbook;
+
+import com.comicbookreader.cleanupcrew.AppDataCleanup;
+import com.comicbookreader.cleanupcrew.UserDataCleanup;
+
+import javax.swing.*;
+import java.io.IOException;
+
+
+public class SettingsMenu {
+    private JMenuBar menuBar;
+
+    public SettingsMenu(){
+        menuBar = new JMenuBar();
+
+        JMenu settingsMenu = new JMenu("Settings");
+        JMenuItem appdataSettings = new JMenuItem("Remove Appdata");
+        JMenuItem userSettings = new JMenuItem("Remove Userdata");
+
+        appdataSettings.addActionListener(e -> {
+            try {
+                showAppdataSettingsDialog();
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+
+        userSettings.addActionListener(e -> {
+            try {
+                showUserDataSettingsDialog();
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+
+        settingsMenu.add(appdataSettings);
+        settingsMenu.add(userSettings); // not implemented
+        menuBar.add(settingsMenu);
+    }
+
+    public JMenuBar getMenuBar() {
+        return menuBar;
+    }
+
+    private void showAppdataSettingsDialog() throws IOException {
+        int result = JOptionPane.showConfirmDialog(
+                null,
+                "Do you want to delete appdata?\n(This will not delete saved comic books)",
+                "Warning!",
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.WARNING_MESSAGE
+        );
+
+        if(result == JOptionPane.OK_OPTION){
+            new AppDataCleanup();
+        }
+    }
+
+    private void showUserDataSettingsDialog() throws IOException {
+        int result = JOptionPane.showConfirmDialog(
+                null,
+                "Do you want to delete userdata?\n(This will not delete saved comic books)",
+                "Warning!",
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.WARNING_MESSAGE
+        );
+
+        if(result == JOptionPane.OK_OPTION){
+            new UserDataCleanup();
+        }
+    }
+
+    private void showSettingsDialog(){
+        JOptionPane.showMessageDialog(null, "Test Message");
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `SettingsMenu` for managing application and user data cleanup, and integrates it into the main application. Additionally, it includes the implementation of two new classes, `AppDataCleanup` and `UserDataCleanup`, to handle the cleanup processes.

Key changes include:

### New Features
* **Settings Menu Integration**:
  - Added a `SettingsMenu` class to provide a GUI for removing app data and user data. (`src/main/java/com/comicbookreader/comicbook/SettingsMenu.java`)
  - Integrated `SettingsMenu` into the main application UI. (`src/main/java/com/comicbookreader/comicbook/Mainmenu.java`)

### Application Enhancements
* **System Property for macOS**:
  - Set the `apple.laf.useScreenMenuBar` property to `true` for better macOS integration. (`src/main/java/com/comicbookreader/Main.java`)
  - Ensured the Swing GUI is started using `SwingUtilities.invokeLater`. (`src/main/java/com/comicbookreader/Main.java`)

### Cleanup Functionality
* **App Data Cleanup**:
  - Implemented `AppDataCleanup` class to handle the deletion of application data. (`src/main/java/com/comicbookreader/cleanupcrew/AppDataCleanup.java`)
* **User Data Cleanup**:
  - Implemented `UserDataCleanup` class to handle the deletion of user data. (`src/main/java/com/comicbookreader/cleanupcrew/UserDataCleanup.java`)